### PR TITLE
Fix 1974a4a breaking tun2socks config

### DIFF
--- a/app/src/main/java/io/github/saeeddev94/xray/service/TProxyService.kt
+++ b/app/src/main/java/io/github/saeeddev94/xray/service/TProxyService.kt
@@ -258,12 +258,12 @@ class TProxyService : VpnService() {
                 "tunnel:",
                 "  name: $tunName",
                 "  mtu: ${settings.tunMtu}",
-                "socks5:",
-                "  address: ${settings.socksAddress}",
-                "  port: ${settings.socksPort}",
                 "misc:",
                 "  tcp-read-write-timeout: ${settings.tunTcpReadWriteTimeout}",
                 "  udp-read-write-timeout: ${settings.tunUdpReadWriteTimeout}",
+                "socks5:",
+                "  address: ${settings.socksAddress}",
+                "  port: ${settings.socksPort}",
             )
             if (
                 settings.socksUsername.trim().isNotEmpty() &&


### PR DESCRIPTION
Commit [1974a4a](https://github.com/SaeedDev94/Xray/commit/1974a4adfb7c3e936590f4345bc13a310e70a939) adds new config options to the tun2socks config, but in a way that username, password and udp sub-options from socks5 section are now in misc section (where they shouldn't be), see [app/src/main/java/io/github/saeeddev94/xray/service/TProxyService.kt](https://github.com/SaeedDev94/Xray/blob/1974a4adfb7c3e936590f4345bc13a310e70a939/app/src/main/java/io/github/saeeddev94/xray/service/TProxyService.kt#L257):
```kt
            /** Create, Update tun2socks config */
            val tun2socksConfig = arrayListOf(
                "tunnel:",
                "  name: $tunName",
                "  mtu: ${settings.tunMtu}",
                "socks5:",
                "  address: ${settings.socksAddress}",
                "  port: ${settings.socksPort}",
                "misc:",
                "  tcp-read-write-timeout: ${settings.tunTcpReadWriteTimeout}",
                "  udp-read-write-timeout: ${settings.tunUdpReadWriteTimeout}",
            )
            if (
                settings.socksUsername.trim().isNotEmpty() &&
                settings.socksPassword.trim().isNotEmpty()
            ) {
                tun2socksConfig.add("  username: ${settings.socksUsername}")
                tun2socksConfig.add("  password: ${settings.socksPassword}")
            }
            tun2socksConfig.add(if (settings.socksUdp) "  udp: udp" else "  udp: tcp")
```

This PR fixes the issue by moving the misc section above the socks5 section.